### PR TITLE
Caching for Api calls

### DIFF
--- a/internal/api/map.go
+++ b/internal/api/map.go
@@ -12,7 +12,6 @@ type ApiResponse struct {
 	Previous *string        `json:"previous"`
 	Next     string         `json:"next"`
 	Results  []LocationArea `json:"results"`
-	Count    int            `json:"count"`
 }
 type LocationArea struct {
 	Name string `json:"name"`

--- a/internal/api/map.go
+++ b/internal/api/map.go
@@ -19,15 +19,15 @@ type LocationArea struct {
 }
 
 type Map struct {
-	Next     string
-	Previous string
+	next     string
+	previous string
 }
 
 func (m *Map) NextLocations() ([]LocationArea, error) {
-	if m.Next == "" {
-		m.Next = locationUrl
+	if m.next == "" {
+		m.next = locationUrl
 	}
-	resData, err := m.callApi(m.Next)
+	resData, err := m.callApi(m.next)
 	if err != nil {
 		return nil, err
 	}
@@ -35,10 +35,10 @@ func (m *Map) NextLocations() ([]LocationArea, error) {
 }
 
 func (m *Map) PreviousLocations() ([]LocationArea, error) {
-	if m.Previous == "" {
+	if m.previous == "" {
 		return nil, fmt.Errorf("Navigation error: On first page!")
 	}
-	resData, err := m.callApi(m.Previous)
+	resData, err := m.callApi(m.previous)
 	if err != nil {
 		return nil, err
 	}
@@ -58,11 +58,11 @@ func (m *Map) callApi(url string) (ApiResponse, error) {
 	dec := json.NewDecoder(res.Body)
 	var resData ApiResponse
 	dec.Decode(&resData)
-	m.Next = resData.Next
+	m.next = resData.Next
 	if resData.Previous == nil {
-		m.Previous = ""
+		m.previous = ""
 	} else {
-		m.Previous = *(resData.Previous)
+		m.previous = *(resData.Previous)
 	}
 	return resData, nil
 }

--- a/internal/api/map.go
+++ b/internal/api/map.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -14,30 +15,26 @@ type ApiResponse struct {
 	Results  json.RawMessage `json:"results"`
 }
 
-func NextLocations(url string) (ApiResponse, error) {
+func GetLocations(url string) ([]byte, error) {
 	if url == "" {
 		url = locationUrl
 	}
-	resData, err := callApi(url)
+	res, err := callApi(url)
 	if err != nil {
-		return ApiResponse{}, err
+		return nil, err
 	}
-	return resData, nil
+	return res, nil
 }
 
-func callApi(url string) (ApiResponse, error) {
+func callApi(url string) ([]byte, error) {
 	res, err := http.Get(url)
 	if err != nil {
-		return ApiResponse{}, err
+		return nil, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return ApiResponse{}, fmt.Errorf("Invalid error code: %d", res.StatusCode)
+		return nil, fmt.Errorf("Invalid error code: %d", res.StatusCode)
 	}
 
-	dec := json.NewDecoder(res.Body)
-	var resData ApiResponse
-	dec.Decode(&resData)
-
-	return resData, nil
+	return io.ReadAll(res.Body)
 }

--- a/internal/api/map.go
+++ b/internal/api/map.go
@@ -9,13 +9,9 @@ import (
 const locationUrl string = "https://pokeapi.co/api/v2/location/"
 
 type ApiResponse struct {
-	Previous *string        `json:"previous"`
-	Next     string         `json:"next"`
-	Results  []LocationArea `json:"results"`
-}
-type LocationArea struct {
-	Name string `json:"name"`
-	Id   int    `json:"id"`
+	Previous *string         `json:"previous"`
+	Next     string          `json:"next"`
+	Results  json.RawMessage `json:"results"`
 }
 
 type Map struct {
@@ -23,26 +19,26 @@ type Map struct {
 	previous string
 }
 
-func (m *Map) NextLocations() ([]LocationArea, error) {
+func (m *Map) NextLocations() (ApiResponse, error) {
 	if m.next == "" {
 		m.next = locationUrl
 	}
 	resData, err := m.callApi(m.next)
 	if err != nil {
-		return nil, err
+		return ApiResponse{}, err
 	}
-	return resData.Results, nil
+	return resData, nil
 }
 
-func (m *Map) PreviousLocations() ([]LocationArea, error) {
+func (m *Map) PreviousLocations() (ApiResponse, error) {
 	if m.previous == "" {
-		return nil, fmt.Errorf("Navigation error: On first page!")
+		return ApiResponse{}, fmt.Errorf("Navigation error: On first page!")
 	}
 	resData, err := m.callApi(m.previous)
 	if err != nil {
-		return nil, err
+		return ApiResponse{}, err
 	}
-	return resData.Results, nil
+	return resData, nil
 }
 
 func (m *Map) callApi(url string) (ApiResponse, error) {

--- a/internal/api/map.go
+++ b/internal/api/map.go
@@ -14,34 +14,18 @@ type ApiResponse struct {
 	Results  json.RawMessage `json:"results"`
 }
 
-type Map struct {
-	next     string
-	previous string
-}
-
-func (m *Map) NextLocations() (ApiResponse, error) {
-	if m.next == "" {
-		m.next = locationUrl
+func NextLocations(url string) (ApiResponse, error) {
+	if url == "" {
+		url = locationUrl
 	}
-	resData, err := m.callApi(m.next)
+	resData, err := callApi(url)
 	if err != nil {
 		return ApiResponse{}, err
 	}
 	return resData, nil
 }
 
-func (m *Map) PreviousLocations() (ApiResponse, error) {
-	if m.previous == "" {
-		return ApiResponse{}, fmt.Errorf("Navigation error: On first page!")
-	}
-	resData, err := m.callApi(m.previous)
-	if err != nil {
-		return ApiResponse{}, err
-	}
-	return resData, nil
-}
-
-func (m *Map) callApi(url string) (ApiResponse, error) {
+func callApi(url string) (ApiResponse, error) {
 	res, err := http.Get(url)
 	if err != nil {
 		return ApiResponse{}, err
@@ -54,11 +38,6 @@ func (m *Map) callApi(url string) (ApiResponse, error) {
 	dec := json.NewDecoder(res.Body)
 	var resData ApiResponse
 	dec.Decode(&resData)
-	m.next = resData.Next
-	if resData.Previous == nil {
-		m.previous = ""
-	} else {
-		m.previous = *(resData.Previous)
-	}
+
 	return resData, nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,8 +18,12 @@ func Run() {
 			return
 		}
 		command := scanner.Text()
-		if err := CommandMap[command].callback(); err != nil {
-			fmt.Println(err.Error())
+		if cmd, exists := CommandMap[command]; exists {
+			if err := cmd.callback(); err != nil {
+				fmt.Println(err.Error())
+			}
+		} else {
+			fmt.Println("Invalid command:", command)
 		}
 	}
 }

--- a/internal/cli/command_map.go
+++ b/internal/cli/command_map.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/codingchem/pokedexcli/internal/api"
+	"github.com/codingchem/pokedexcli/internal/datastore"
 )
 
 type cliCommand struct {
@@ -27,7 +27,7 @@ func commandExit() error {
 }
 
 func mapCommand() error {
-	curLocation, err := locations.NextLocations()
+	curLocation, err := locations.Next()
 	if err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func mapCommand() error {
 }
 
 func mapbCommand() error {
-	curLocation, err := locations.PreviousLocations()
+	curLocation, err := locations.Prev()
 	if err != nil {
 		return err
 	}
@@ -49,6 +49,7 @@ func mapbCommand() error {
 }
 
 func initCommands() {
+	locations = datastore.NewLocationStore()
 	CommandMap = map[string]cliCommand{
 		"help": {
 			name:        "help",
@@ -75,5 +76,5 @@ func initCommands() {
 
 var (
 	CommandMap map[string]cliCommand
-	locations  api.Map
+	locations  datastore.ILocationStore
 )

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -60,9 +60,14 @@ func NewLocationStore() *LocationStore {
 }
 
 func (l *LocationStore) getData(url string) (api.ApiResponse, error) {
-	data, err := api.GetLocations(url)
-	if err != nil {
-		return api.ApiResponse{}, err
+	data, ok := l.cache.Get(url)
+	var err error
+	if !ok {
+		data, err = api.GetLocations(url)
+		if err != nil {
+			return api.ApiResponse{}, err
+		}
+		l.cache.Add(url, data)
 	}
 	var res api.ApiResponse
 	err = json.Unmarshal(data, &res)

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/codingchem/pokedexcli/internal/api"
 	"github.com/codingchem/pokedexcli/internal/pokecache"
@@ -18,14 +19,13 @@ type LocationArea struct {
 }
 
 type LocationStore struct {
-	prev   *string
-	oldmap *api.Map
-	cache  *pokecache.Cache
-	next   string
+	prev  *string
+	cache *pokecache.Cache
+	next  string
 }
 
 func (l *LocationStore) Next() ([]LocationArea, error) {
-	res, err := l.oldmap.NextLocations()
+	res, err := api.NextLocations(l.next)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,10 @@ func (l *LocationStore) Next() ([]LocationArea, error) {
 }
 
 func (l *LocationStore) Prev() ([]LocationArea, error) {
-	res, err := l.oldmap.PreviousLocations()
+	if l.prev == nil {
+		return nil, fmt.Errorf("Already on first page!")
+	}
+	res, err := api.NextLocations(*l.prev)
 	if err != nil {
 		return nil, err
 	}
@@ -56,9 +59,8 @@ func (l *LocationStore) Prev() ([]LocationArea, error) {
 
 func NewLocationStore() *LocationStore {
 	return &LocationStore{
-		next:   "",
-		prev:   nil,
-		oldmap: &api.Map{},
-		cache:  pokecache.NewCache(10),
+		next:  "",
+		prev:  nil,
+		cache: pokecache.NewCache(10),
 	}
 }

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -29,8 +29,7 @@ func (l *LocationStore) Next() ([]LocationArea, error) {
 	if err != nil {
 		return nil, err
 	}
-	var locs []LocationArea
-	err = json.Unmarshal(res.Results, &locs)
+	locs, err := l.unmarshal(res.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +44,7 @@ func (l *LocationStore) Prev() ([]LocationArea, error) {
 	if err != nil {
 		return nil, err
 	}
-	var locs []LocationArea
-	err = json.Unmarshal(res.Results, &locs)
+	locs, err := l.unmarshal(res.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -74,4 +72,13 @@ func (l *LocationStore) getData(url string) (api.ApiResponse, error) {
 	l.next = res.Next
 	l.prev = res.Previous
 	return res, nil
+}
+
+func (l *LocationStore) unmarshal(data []byte) ([]LocationArea, error) {
+	var locs []LocationArea
+	err := json.Unmarshal(data, &locs)
+	if err != nil {
+		return nil, err
+	}
+	return locs, nil
 }

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -1,33 +1,62 @@
 package datastore
 
 import (
+	"encoding/json"
+
 	"github.com/codingchem/pokedexcli/internal/api"
 	"github.com/codingchem/pokedexcli/internal/pokecache"
 )
 
 type ILocationStore interface {
-	Next() ([]api.LocationArea, error)
-	Prev() ([]api.LocationArea, error)
+	Next() ([]LocationArea, error)
+	Prev() ([]LocationArea, error)
+}
+
+type LocationArea struct {
+	Name string `json:"name"`
+	Id   int    `json:"id"`
 }
 
 type LocationStore struct {
-	next   *string
 	prev   *string
 	oldmap *api.Map
 	cache  *pokecache.Cache
+	next   string
 }
 
-func (l *LocationStore) Next() ([]api.LocationArea, error) {
-	return l.oldmap.NextLocations()
+func (l *LocationStore) Next() ([]LocationArea, error) {
+	res, err := l.oldmap.NextLocations()
+	if err != nil {
+		return nil, err
+	}
+	l.next = res.Next
+	l.prev = res.Previous
+	var locs []LocationArea
+	err = json.Unmarshal(res.Results, &locs)
+	if err != nil {
+		return nil, err
+	}
+	return locs, nil
 }
 
-func (l *LocationStore) Prev() ([]api.LocationArea, error) {
-	return l.oldmap.PreviousLocations()
+func (l *LocationStore) Prev() ([]LocationArea, error) {
+	res, err := l.oldmap.PreviousLocations()
+	if err != nil {
+		return nil, err
+	}
+	l.next = res.Next
+	l.prev = res.Previous
+	var locs []LocationArea
+	err = json.Unmarshal(res.Results, &locs)
+	if err != nil {
+		return nil, err
+	}
+	return locs, nil
 }
 
 func NewLocationStore() *LocationStore {
 	return &LocationStore{
-		next:   nil,
+		next:   "",
 		prev:   nil,
 		oldmap: &api.Map{},
 		cache:  pokecache.NewCache(10),

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -1,0 +1,35 @@
+package datastore
+
+import (
+	"github.com/codingchem/pokedexcli/internal/api"
+	"github.com/codingchem/pokedexcli/internal/pokecache"
+)
+
+type ILocationStore interface {
+	Next() ([]api.LocationArea, error)
+	Prev() ([]api.LocationArea, error)
+}
+
+type LocationStore struct {
+	next   *string
+	prev   *string
+	oldmap *api.Map
+	cache  *pokecache.Cache
+}
+
+func (l *LocationStore) Next() ([]api.LocationArea, error) {
+	return l.oldmap.NextLocations()
+}
+
+func (l *LocationStore) Prev() ([]api.LocationArea, error) {
+	return l.oldmap.PreviousLocations()
+}
+
+func NewLocationStore() *LocationStore {
+	return &LocationStore{
+		next:   nil,
+		prev:   nil,
+		oldmap: &api.Map{},
+		cache:  pokecache.NewCache(10),
+	}
+}

--- a/internal/datastore/locations.go
+++ b/internal/datastore/locations.go
@@ -20,7 +20,7 @@ type LocationArea struct {
 
 type LocationStore struct {
 	prev  *string
-	cache *pokecache.Cache
+	cache *pokecache.Cache[api.ApiResponse]
 	next  string
 }
 
@@ -61,6 +61,6 @@ func NewLocationStore() *LocationStore {
 	return &LocationStore{
 		next:  "",
 		prev:  nil,
-		cache: pokecache.NewCache(10),
+		cache: pokecache.NewCache[api.ApiResponse](10),
 	}
 }

--- a/internal/pokecache/cache.go
+++ b/internal/pokecache/cache.go
@@ -1,4 +1,4 @@
-package cache
+package pokecache
 
 import (
 	"sync"

--- a/internal/pokecache/cache.go
+++ b/internal/pokecache/cache.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	createdAt time.Time
+	val       []byte
+}
+
+type Cache struct {
+	Calls map[string]cacheEntry
+	mu    sync.RWMutex
+}
+
+func (c *Cache) Add(key string, value []byte) {
+	c.mu.Lock()
+	c.Calls[key] = cacheEntry{time.Now(), value}
+	c.mu.Unlock()
+}
+
+func NewCache(retainSeconds int) *Cache {
+	c := Cache{}
+	go c.sweepLoop(retainSeconds)
+	return &c
+}
+
+func (c *Cache) Get(key string) (value []byte, success bool) {
+	c.mu.RLock()
+	entry, success := c.Calls[key]
+	if success {
+		return entry.val, success
+	}
+	return nil, success
+}
+
+func (c *Cache) sweepLoop(retainSeconds int) {
+	ticker := time.NewTicker(time.Duration(retainSeconds) * time.Second)
+	for {
+		c.mu.Lock()
+		for key, value := range c.Calls {
+			if time.Until(value.createdAt)*-1 > time.Duration(retainSeconds)*time.Second {
+				delete(c.Calls, key)
+			}
+		}
+		c.mu.Unlock()
+		<-ticker.C
+	}
+}

--- a/internal/pokecache/cache.go
+++ b/internal/pokecache/cache.go
@@ -22,7 +22,7 @@ func (c *Cache[T]) Add(key string, value T) {
 }
 
 func NewCache[T any](retainSeconds int) *Cache[T] {
-	c := Cache[T]{}
+	c := Cache[T]{Calls: make(map[string]cacheEntry[T])}
 	go c.sweepLoop(retainSeconds)
 	return &c
 }

--- a/internal/pokecache/cache.go
+++ b/internal/pokecache/cache.go
@@ -30,6 +30,7 @@ func NewCache(retainSeconds int) *Cache {
 func (c *Cache) Get(key string) (value []byte, success bool) {
 	c.mu.RLock()
 	entry, success := c.Calls[key]
+	c.mu.RUnlock()
 	if success {
 		return entry.val, success
 	}


### PR DESCRIPTION
- **add temporary cache**
- **Removed unused field from type**
- **Fix: Get no longer blocks cache indefinetly**
- **Chore: change names of Next and Previous fields**
- **Fix: fixed typo in package name**
- **Add: implemented locationStore wrapper**
- **Chore: moved LocationArea and parsing logic**
- **Cleanup: Remove obsolete code**
- **Change the cache to use generics**
- **refactor: data aquisition to helper method**
- **Refactor: GetLocations now returns a raw byte array**
- **refactor: make a helper function for unmarshaling**
- **bug: fixed bug where invalid command would crash repl**
- **Bug: cache map field not initialized properly**
- **Feature: Add caching to the getData function**
